### PR TITLE
Py3K syntax fixes

### DIFF
--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -1051,7 +1051,7 @@ class ShellSession(Expect):
         self.sendline(cmd)
         try:
             o = self.read_up_to_prompt(timeout, internal_timeout, print_func)
-        except ExpectError, e:
+        except ExpectError as e:
             o = self.remove_command_echo(e.output, cmd)
             if isinstance(e, ExpectTimeoutError):
                 raise ShellTimeoutError(cmd, o)
@@ -1093,7 +1093,7 @@ class ShellSession(Expect):
                 o += self.read_up_to_prompt(0.5)
                 success = True
                 break
-            except ExpectError, e:
+            except ExpectError as e:
                 o = self.remove_command_echo(e.output, cmd)
                 if isinstance(e, ExpectTimeoutError):
                     self.sendline()

--- a/aexpect/shared.py
+++ b/aexpect/shared.py
@@ -65,10 +65,10 @@ def makestandard(shell_fd, echo):
 
 
 def get_filenames(base_dir):
-    return [os.path.join(base_dir, s) for s in
-            "shell-pid", "status", "output", "inpipe", "ctrlpipe",
-            "lock-server-running", "lock-client-starting",
-            "server-log"]
+    files = ("shell-pid", "status", "output", "inpipe", "ctrlpipe",
+             "lock-server-running", "lock-client-starting",
+             "server-log")
+    return [os.path.join(base_dir, s) for s in files]
 
 
 def get_reader_filename(base_dir, reader):


### PR DESCRIPTION
These are simple Python 3 syntax changes that adds compatibility
(as far as I exercised it) to aexpect.

Signed-off-by: Cleber Rosa <crosa@redhat.com>