### PR TITLE
Support for python3

### DIFF
--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -160,12 +160,13 @@ class Spawn(object):
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.STDOUT)
             # Send parameters to the server
-            sub.stdin.write("%s\n" % self.a_id)
-            sub.stdin.write("%s\n" % echo)
-            sub.stdin.write("%s\n" % ",".join(self.readers))
-            sub.stdin.write("%s\n" % command)
+            sub.stdin.write(("%s\n" % self.a_id).encode())
+            sub.stdin.write(("%s\n" % echo).encode())
+            sub.stdin.write(("%s\n" % ",".join(self.readers)).encode())
+            sub.stdin.write(("%s\n" % command).encode())
             # Wait for the server to complete its initialization
-            while "Server %s ready" % self.a_id not in sub.stdout.readline():
+            while ("Server %s ready" % self.a_id not in
+                   sub.stdout.readline().decode()):
                 pass
 
         # Open the reading pipes
@@ -359,7 +360,7 @@ class Spawn(object):
         """
         try:
             fd = os.open(self.inpipe_filename, os.O_RDWR)
-            os.write(fd, cont)
+            os.write(fd, cont.encode())
             os.close(fd)
         except OSError:
             pass
@@ -381,7 +382,7 @@ class Spawn(object):
         """
         try:
             fd = os.open(self.ctrlpipe_filename, os.O_RDWR)
-            os.write(fd, "%10d%s" % (len(control_str), control_str))
+            os.write(fd, ("%10d%s" % (len(control_str), control_str)).encode())
             os.close(fd)
         except OSError:
             pass
@@ -560,7 +561,7 @@ class Tail(Spawn):
                     break
                 if fd in r:
                     # Some data is available; read it
-                    new_data = os.read(fd, 1024)
+                    new_data = os.read(fd, 1024).decode()
                     if not new_data:
                         break
                     bfr += new_data
@@ -683,7 +684,7 @@ class Expect(Tail):
             except (select.error, TypeError):
                 return data
             if fd in r:
-                new_data = os.read(fd, 1024)
+                new_data = os.read(fd, 1024).decode()
                 if not new_data:
                     return data
                 data += new_data

--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -164,6 +164,7 @@ class Spawn(object):
             sub.stdin.write(("%s\n" % echo).encode())
             sub.stdin.write(("%s\n" % ",".join(self.readers)).encode())
             sub.stdin.write(("%s\n" % command).encode())
+            sub.stdin.flush()
             # Wait for the server to complete its initialization
             while ("Server %s ready" % self.a_id not in
                    sub.stdout.readline().decode()):

--- a/aexpect/utils/data_factory.py
+++ b/aexpect/utils/data_factory.py
@@ -19,7 +19,7 @@ def generate_random_string(length, ignore=string.punctuation,
     :return: The generated random string.
     """
     result = ""
-    chars = string.letters + string.digits + string.punctuation
+    chars = string.ascii_letters + string.digits + string.punctuation
     if not ignore:
         ignore = ""
     for i in ignore:

--- a/aexpect/utils/process.py
+++ b/aexpect/utils/process.py
@@ -1,6 +1,12 @@
-import commands
+import subprocess
 import signal
 import os
+
+
+def getoutput(cmd):
+    proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)
+    return proc.communicate()[0].decode().rstrip("\n\r")
 
 
 class CmdError(Exception):
@@ -48,7 +54,7 @@ def kill_process_tree(pid, sig=signal.SIGKILL):
     """
     if not safe_kill(pid, signal.SIGSTOP):
         return
-    children = commands.getoutput("ps --ppid=%d -o pid=" % pid).split()
+    children = getoutput("ps --ppid=%d -o pid=" % pid).split()
     for child in children:
         kill_process_tree(int(child), sig)
     safe_kill(pid, sig)
@@ -61,7 +67,7 @@ def get_children_pids(ppid):
     param ppid: parent PID
     return: list of PIDs of all children/threads of ppid
     """
-    return commands.getoutput("ps -L --ppid=%d -o lwp" % ppid).split('\n')[1:]
+    return getoutput("ps -L --ppid=%d -o lwp" % ppid).split('\n')[1:]
 
 
 def process_in_ptree_is_defunct(ppid):
@@ -80,7 +86,7 @@ def process_in_ptree_is_defunct(ppid):
         return True
     for pid in pids:
         cmd = "ps --no-headers -o cmd %d" % int(pid)
-        proc_name = commands.getoutput(cmd)
+        proc_name = getoutput(cmd)
         if '<defunct>' in proc_name:
             defunct = True
             break

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@
 import os
 # pylint: disable=E0611
 
-from distutils.core import setup
+from setuptools import setup
 
 VIRTUAL_ENV = 'VIRTUAL_ENV' in os.environ
 
@@ -58,4 +58,5 @@ if __name__ == '__main__':
           url='http://avocado-framework.github.io/',
           packages=['aexpect',
                     'aexpect.utils'],
-          scripts=['scripts/aexpect-helper'])
+          scripts=['scripts/aexpect-helper'],
+          use_2to3=True)


### PR DESCRIPTION
This extends the initial python3 support from https://github.com/autotest/aexpect/pull/7. Not every functionality was tested on python3, but the basic workflow with `ShellSession` works well (using python2 aexpect-worker, which needs to be adjusted before declaring aexpect fully python3 compatible)