### PR TITLE
Makefile: Remove the unsupported --prune argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all:
 	@echo "make clean - Get rid of scratch and byte files"
 
 source:
-	$(PYTHON) setup.py sdist $(COMPILE) --dist-dir=SOURCES --prune
+	$(PYTHON) setup.py sdist $(COMPILE) --dist-dir=SOURCES
 
 install:
 	$(PYTHON) setup.py install --root $(DESTDIR) $(COMPILE)
@@ -26,7 +26,7 @@ prepare-source:
 	# build the source package in the parent directory
 	# then rename it to project_version.orig.tar.gz
 	dch -D "utopic" -M -v "$(VERSION)" "Automated (make builddeb) build."
-	$(PYTHON) setup.py sdist $(COMPILE) --dist-dir=../ --prune
+	$(PYTHON) setup.py sdist $(COMPILE) --dist-dir=../
 	rename -f 's/$(PROJECT)-(.*)\.tar\.gz/$(PROJECT)_$$1\.orig\.tar\.gz/' ../*
 
 build-deb-src: prepare-source


### PR DESCRIPTION
The setuptools which replaced the distutils in
0f405f8d757a55abf82af24d9b7141e96469e9cd does not support the `--prune`
argument, making it impossible to build packages. Let's adjust the
Makefile.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>