### PR TITLE
aexpect.client: Add support to sendcontrol characters

### DIFF
--- a/aexpect/client.py
+++ b/aexpect/client.py
@@ -374,6 +374,28 @@ class Spawn(object):
         """
         self.send(cont + self.linesep)
 
+    def sendcontrol(self, char):
+        """
+        This sends a control character to the child such as Ctrl-C or
+        Ctrl-D. For example, to send a Ctrl-G (ASCII 7)::
+        session.sendcontrol('g')
+        :param char: single character you want to send (ctrl+$char)
+        :raise KeyError: When unable to map char to ctrl+comand
+        """
+        char = char.lower()
+        val = ord(char)
+        if val >= 97 and val <= 122:
+            val = val - 97 + 1  # ctrl+a = '\0x01'
+            return self.send(chr(val))
+        mapping = {'@': 0, '`': 0,
+                   '[': 27, '{': 27,
+                   '\\': 28, '|': 28,
+                   ']': 29, '}': 29,
+                   '^': 30, '~': 30,
+                   '_': 31,
+                   '?': 127}
+        return self.send(chr(mapping[char]))
+
     def send_ctrl(self, control_str=""):
         """
         Send a control string to the aexpect process.


### PR DESCRIPTION
From time to time one needs to send ctrl+... characters to the
underlying process. One can either find and use the actual value, or
they can use this function, which does the mapping itself. To use it
simply specify the key to be pressed together with ctrl and you're set.

Note: Don't mistake this method with send_ctrl, which is used to send
control messages to the aexpect process and not to your underlying
process.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>